### PR TITLE
Fix Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: required
+dist: xenial
 language: python
 python:
   - 3.4

--- a/russound_rio/rio.py
+++ b/russound_rio/rio.py
@@ -205,7 +205,7 @@ class Russound:
             queue_future.cancel()
             net_future.cancel()
             raise
-        except:
+        except Exception:
             logger.exception("Unhandled exception in IO loop")
             raise
 

--- a/russound_rio/rio.py
+++ b/russound_rio/rio.py
@@ -2,10 +2,11 @@ import asyncio
 import re
 import logging
 
-try:
-    from asyncio import ensure_future
-except ImportError:
-    from asyncio import async as ensure_future
+# Maintain compat with various 3.x async changes
+if hasattr(asyncio, 'ensure_future'):
+    ensure_future = asyncio.ensure_future
+else:
+    ensure_future = getattr(asyncio, 'async')
 
 logger = logging.getLogger('russound')
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
         name='russound_rio',
-        version='0.1.4',
+        version='0.1.5',
         packages=['russound_rio'],
         license='MIT',
         author='Martin Donlon',

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,6 @@ commands = flake8 russound_rio/
 [travis]
 python =
   3.4: py34, flake8
-  3.5: py35
-  3.6: py36
-  3.7: py37
+  3.5: py35, flake8
+  3.6: py36, flake8
+  3.7: py37, flake8


### PR DESCRIPTION
Update async imports so they work with python3.7 now that 'async' is a reserved keyword.
Include 3.7 in CI