### PR TITLE
Update rio.py - BugFix: _watched_sources

### DIFF
--- a/russound_rio/rio.py
+++ b/russound_rio/rio.py
@@ -375,7 +375,7 @@ class Russound:
         source_id = int(source_id)
         r = yield from self._send_cmd(
                 "WATCH S[%d] ON" % (source_id, ))
-        self._watched_source.add(source_id)
+        self._watched_sources.add(source_id)
         return r
 
     @asyncio.coroutine


### PR DESCRIPTION
Line 378 Changed from:      
 self._watched_source.add(source_id)
To:
self._watched_sources.add(source_id)

To match self variable name.