### PR TITLE
Added Internal Tuner Preset Functionality

### DIFF
--- a/russound_rio/rio.py
+++ b/russound_rio/rio.py
@@ -375,7 +375,7 @@ class Russound:
         source_id = int(source_id)
         r = yield from self._send_cmd(
                 "WATCH S[%d] ON" % (source_id, ))
-        self._watched_source.add(source_id)
+        self._watched_sources.add(source_id)
         return r
 
     @asyncio.coroutine


### PR DESCRIPTION
Added functionality to pull preset information, store it in cached variables as well as to change source to internal tuner stations.

Will need to modify media_player.py for home assistant core if pulled into main. I have the code for this as well but unsure where rio.py is pulled into within the home assistant core repository. 