### PR TITLE
Py3.11 compatibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:0-3.11"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install pypa/build
       run: >-

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Martin Donlon
+Copyright (c) 2023 Chris Phillips
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -10,32 +10,31 @@ sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
 from russound_rio import Russound, ZoneID  # noqa: E402
 
 
-@asyncio.coroutine
-def demo(loop, host):
+async def demo(loop, host):
     rus = Russound(loop, host)
-    yield from rus.connect()
+    await rus.connect()
 
     print("Determining valid zones")
     # Determine Zones
-    valid_zones = yield from rus.enumerate_zones()
+    valid_zones = await rus.enumerate_zones()
 
     for zone_id, name in valid_zones:
         print("%s: %s" % (zone_id, name))
 
-    sources = yield from rus.enumerate_sources()
+    sources = await rus.enumerate_sources()
     for source_id, name in sources:
         print("%s: %s" % (source_id, name))
 
-    yield from rus.watch_zone(ZoneID(1))
-    yield from asyncio.sleep(1)
-    yield from rus.send_zone_event(ZoneID(1), "KeyPress", "Volume", 40)
-    yield from asyncio.sleep(1)
-    r = yield from rus.get_zone_variable(ZoneID(1), "volume")
+    await rus.watch_zone(ZoneID(1))
+    await asyncio.sleep(1)
+    await rus.send_zone_event(ZoneID(1), "KeyPress", "Volume", 40)
+    await asyncio.sleep(1)
+    r = await rus.get_zone_variable(ZoneID(1), "volume")
     print("Volume:", r)
     source = rus.get_cached_zone_variable(ZoneID(1), "currentsource")
-    name = yield from rus.get_source_variable(source, 'name')
+    name = await rus.get_source_variable(source, 'name')
     print("Zone 1 source name: %s" % name)
-    yield from rus.close()
+    await rus.close()
     print("Done")
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ from distutils.core import setup
 
 setup(
         name='russound_rio',
-        version='0.1.9',
+        version='0.2.0',
         packages=['russound_rio'],
         license='MIT',
-        author='Martin Donlon',
-        url='https://github.com/wickerwaka/russound_rio',
+        author='Chris Phillips',
+        url='https://github.com/chphilli/russound_rio',
         description='Asyncio client for Russound RIO devices',
         long_description=open('README.rst').read(),
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
         name='russound_rio',
-        version='0.1.8',
+        version='0.1.9',
         packages=['russound_rio'],
         license='MIT',
         author='Martin Donlon',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, py310, flake8
+envlist = py37, py38, py39, py310, py311, flake8
 
 [testenv]
 commands = pytest
@@ -23,3 +23,4 @@ python =
   3.8: py38, flake8
   3.9: py39, flake8
   3.10: py310, flake8
+  3.11: py311, flake8


### PR DESCRIPTION
Simple update to fix #13 ( and ultimately, https://github.com/home-assistant/core/issues/94295 ). 

This change:
   - adds Python 3.11 as a target for building, testing, and packaging
   - changes the rio.py & examples/basic.py usage of `@asyncio.coroutines` to `async def` ( and associated `yield`s to `await`s )
   - adds a basic `devcontainer.json` to make building/testing easier
   - bumps the package version to 1.9 (I think that's the right way to do this?)

The basic.py script successfully listed the zones and sources on my local Russound device, so I think this is working as intended. 